### PR TITLE
Update dependencies for Ubuntu 24.04. in workflow file

### DIFF
--- a/.github/workflows/dynare-6.0-matlab-ubuntu.yml
+++ b/.github/workflows/dynare-6.0-matlab-ubuntu.yml
@@ -54,7 +54,7 @@ jobs:
               libsuitesparse-dev flex libfl-dev bison texlive texlive-publishers \
               texlive-latex-extra texlive-fonts-extra texlive-font-utils texlive-latex-recommended \
               texlive-science texlive-plain-generic lmodern python3-sphinx tex-gyre latexmk \
-              libjs-mathjax x13as liboctave-dev octave-control octave-econometrics octave-io \
+              libjs-mathjax x13as octave-dev octave-control octave-econometrics octave-io \
               octave-statistics octave-struct octave-parallel gnuplot fonts-freefont-otf \
               ghostscript epstool git git-lfs
      


### PR DESCRIPTION
Name of liboctave-dev changed to octave-dev in 24.04
